### PR TITLE
Remove ONESHELL requirement for all make recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 BINDATA_OUTPUT_FILE := ./pkg/bindata/bindata.go
-.ONESHELL:
 .ensure-go-bindata:
 	ln -s $(abspath ./vendor) "$${TMP_GOPATH}/src"
 	export GO111MODULE=off && export GOPATH=$${TMP_GOPATH} && export GOBIN=$${TMP_GOPATH}/bin && GOFLAGS=$(GOFLAGS) go install "./vendor/github.com/go-bindata/go-bindata/..."
@@ -97,18 +96,18 @@ BINDATA_OUTPUT_FILE := ./pkg/bindata/bindata.go
 .PHONY: .run-bindata
 
 update-bindata:
-	export TMP_GOPATH=$$(mktemp -d)
-	$(MAKE) .run-bindata
+	export TMP_GOPATH=$$(mktemp -d) ;\
+	$(MAKE) .run-bindata ;\
 	rm -rf "$${TMP_GOPATH}"
 .PHONY: update-bindata
 
 verify-bindata:
-	export TMP_GOPATH=$$(mktemp -d)
-	export TMP_DIR=$$(mktemp -d)
-	export BINDATA_OUTPUT_PREFIX="$${TMP_DIR}/"
-	$(MAKE) .run-bindata
-	diff -Naup {.,$${TMP_DIR}}/$(BINDATA_OUTPUT_FILE)
-	rm -rf "$${TMP_DIR}"
+	export TMP_GOPATH=$$(mktemp -d) ;\
+	export TMP_DIR=$$(mktemp -d) ;\
+	export BINDATA_OUTPUT_PREFIX="$${TMP_DIR}/" ;\
+	$(MAKE) .run-bindata ;\
+	diff -Naup {.,$${TMP_DIR}}/$(BINDATA_OUTPUT_FILE) ;\
+	rm -rf "$${TMP_DIR}" ;\
 	rm -rf "$${TMP_GOPATH}"
 .PHONY: verify-bindata
 


### PR DESCRIPTION
This removes the one shell requirement to have all make recipe lines
passed to a single shell invocation. While this can improve performance
and is useful for sharing environment variables across recipe lines
without `;` and escaping the newline character, once it is set anywhere
in the Makefile, then all make recipe lines for each target will be
provided to a single invocation of the shell. This removal will avoid
any confusion and keep the Makefile contents as consistent as possible
to the originally generated Makefile from operator-sdk.