### PR TITLE
Tag most Makefile targets as .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
+# Get the current kustomize binary. If there isn't any, we'll use the
+# GOBIN path
+ifeq (, $(shell which kustomize))
+KUSTOMIZE=$(GOBIN)/kustomize
+else
+KUSTOMIZE=$(shell which kustomize)
+endif
+
 # Use the vendored directory
 GOFLAGS = -mod=vendor
 
@@ -157,9 +165,10 @@ $(CONTROLLER_GEN):
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 
-.PHONY: controller-gen
-kustomize:
-ifeq (, $(shell which kustomize))
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE)
+
+$(KUSTOMIZE):
 	@{ \
 	set -e ;\
 	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
@@ -168,10 +177,6 @@ ifeq (, $(shell which kustomize))
 	go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
 	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
 	}
-KUSTOMIZE=$(GOBIN)/kustomize
-else
-KUSTOMIZE=$(shell which kustomize)
-endif
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,14 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Get the current controller-gen binary. If there isn't any, we'll use the
+# GOBIN path
+ifeq (, $(shell which controller-gen))
+CONTROLLER_GEN=$(GOBIN)/controller-gen
+else
+CONTROLLER_GEN=$(shell which controller-gen)
+endif
+
 # Use the vendored directory
 GOFLAGS = -mod=vendor
 
@@ -137,8 +145,9 @@ docker-push:
 # find or download controller-gen
 # download controller-gen if necessary
 .PHONY: controller-gen
-controller-gen:
-ifeq (, $(shell which controller-gen))
+controller-gen: $(CONTROLLER_GEN)
+
+$(CONTROLLER_GEN):
 	@{ \
 	set -e ;\
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
@@ -147,10 +156,6 @@ ifeq (, $(shell which controller-gen))
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
-endif
 
 .PHONY: controller-gen
 kustomize:


### PR DESCRIPTION
Makefile expects the target to be a file, this isn't applicable to most
targets in the Makefile. So let's mark them as such for good make
hygiene.

This also changes the `kustomize` and `controller-gen` targets to be more
make-like by making them depend on the binaries as targets.