### PR TITLE
Update API spec fields' primitive types

### DIFF
--- a/api/v1alpha1/gatekeeper_types.go
+++ b/api/v1alpha1/gatekeeper_types.go
@@ -62,17 +62,17 @@ type ImageConfig struct {
 type AuditConfig struct {
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	Replicas *int64 `json:"replicas,omitempty"`
+	Replicas *int32 `json:"replicas,omitempty"`
 	// +optional
 	AuditInterval *metav1.Duration `json:"auditInterval,omitempty"`
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	ConstraintViolationLimit *int64 `json:"constraintViolationLimit,omitempty"`
+	ConstraintViolationLimit *uint64 `json:"constraintViolationLimit,omitempty"`
 	// +optional
 	AuditFromCache *AuditFromCacheMode `json:"auditFromCache,omitempty"`
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	AuditChunkSize *int64 `json:"auditChunkSize,omitempty"`
+	AuditChunkSize *uint64 `json:"auditChunkSize,omitempty"`
 	// +optional
 	LogLevel *LogLevelMode `json:"logLevel,omitempty"`
 	// +optional
@@ -90,7 +90,7 @@ const (
 type WebhookConfig struct {
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	Replicas *int64 `json:"replicas,omitempty"`
+	Replicas *int32 `json:"replicas,omitempty"`
 	// +optional
 	LogLevel *LogLevelMode `json:"logLevel,omitempty"`
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -32,7 +32,7 @@ func (in *AuditConfig) DeepCopyInto(out *AuditConfig) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		*out = new(int64)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.AuditInterval != nil {
@@ -42,7 +42,7 @@ func (in *AuditConfig) DeepCopyInto(out *AuditConfig) {
 	}
 	if in.ConstraintViolationLimit != nil {
 		in, out := &in.ConstraintViolationLimit, &out.ConstraintViolationLimit
-		*out = new(int64)
+		*out = new(uint64)
 		**out = **in
 	}
 	if in.AuditFromCache != nil {
@@ -52,7 +52,7 @@ func (in *AuditConfig) DeepCopyInto(out *AuditConfig) {
 	}
 	if in.AuditChunkSize != nil {
 		in, out := &in.AuditChunkSize, &out.AuditChunkSize
-		*out = new(int64)
+		*out = new(uint64)
 		**out = **in
 	}
 	if in.LogLevel != nil {
@@ -278,7 +278,7 @@ func (in *WebhookConfig) DeepCopyInto(out *WebhookConfig) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		*out = new(int64)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.LogLevel != nil {

--- a/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
@@ -661,7 +661,7 @@ spec:
                     - ERROR
                     type: string
                   replicas:
-                    format: int64
+                    format: int32
                     minimum: 0
                     type: integer
                 type: object
@@ -771,7 +771,7 @@ spec:
                     - ERROR
                     type: string
                   replicas:
-                    format: int64
+                    format: int32
                     minimum: 0
                     type: integer
                 type: object

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -318,9 +318,9 @@ func crOverrides(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, manifest
 }
 
 // setReplicas
-func setReplicas(obj *unstructured.Unstructured, replicas *int64) error {
+func setReplicas(obj *unstructured.Unstructured, replicas *int32) error {
 	if replicas != nil {
-		if err := unstructured.SetNestedField(obj.Object, *replicas, "spec", "replicas"); err != nil {
+		if err := unstructured.SetNestedField(obj.Object, int64(*replicas), "spec", "replicas"); err != nil {
 			return errors.Wrapf(err, "Failed to set replica value")
 		}
 	}

--- a/controllers/gatekeeper_controller_test.go
+++ b/controllers/gatekeeper_controller_test.go
@@ -27,14 +27,14 @@ import (
 )
 
 var (
-	auditReplicas   = int64(1)
-	webhookReplicas = int64(3)
+	auditReplicas   = int32(1)
+	webhookReplicas = int32(3)
 )
 
 func TestReplicas(t *testing.T) {
 	g := NewWithT(t)
-	auditReplicaOverride := int64(4)
-	webhookReplicaOverride := int64(7)
+	auditReplicaOverride := int32(4)
+	webhookReplicaOverride := int32(7)
 	gatekeeper := &operatorv1alpha1.Gatekeeper{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -72,10 +72,10 @@ func TestReplicas(t *testing.T) {
 	testManifestReplicas(t, webhookManifest, webhookReplicaOverride)
 }
 
-func testManifestReplicas(t *testing.T, manifest *manifest.Manifest, expectedReplicas int64) {
+func testManifestReplicas(t *testing.T, manifest *manifest.Manifest, expectedReplicas int32) {
 	g := NewWithT(t)
 	replicas, found, err := unstructured.NestedInt64(manifest.Obj.Object, "spec", "replicas")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(found).To(BeTrue())
-	g.Expect(replicas).To(BeIdenticalTo(expectedReplicas))
+	g.Expect(int32(replicas)).To(BeIdenticalTo(expectedReplicas))
 }


### PR DESCRIPTION
This updates the integer primitive types of API spec fields to match the type expected by Gatekeeper and Kubernetes.